### PR TITLE
Make sure entry id can not contain commas

### DIFF
--- a/pdf2bib/bibtex_makers.py
+++ b/pdf2bib/bibtex_makers.py
@@ -178,7 +178,7 @@ def make_bibtex(metadata):
     id = id.lower()
     id = remove_latex_codes(id)
     id = unidecode(id) #This makes sure that the id of the bibtex entry is only made out of ascii characters (i.e. no accents, tildes, etc.)
-    id = id.replace('-','') #Make sure to remove any possible hyphen
+    id = re.sub('-|,', '', id) #Make sure to remove any possible hyphen and comma
     if id == '':
         id = 'NoValidID'
 


### PR DESCRIPTION
With some pdf-files the generated entry id contains a comma. The extra comma is not allowed in bibtex, which results in a bib file with a syntax error. 

This [example pdf](https://www.researchgate.net/profile/Erol-Harvey/publication/228678773_Design_fabrication_and_testing_of_piezoelectric_polymer_PVDF_microactuators/links/561de42408aecade1acb42c4/Design-fabrication-and-testing-of-piezoelectric-polymer-PVDF-microactuators.pdf) results in the following invalid bib entry:

```
@article{fu2005design,,
        title = {Design, fabrication and testing of piezoelectric polymer PVDF microactuators},
        volume = {15},
        issue = {1},
        page = {S141-S146},
        publisher = {IOP Publishing},
        url = {http://dx.doi.org/10.1088/0964-1726/15/1/023},
        doi = {10.1088/0964-1726/15/1/023},
        journal = {Smart Materials and Structures},
        year = {2005},
        month = {12},
        author = {Yao Fu and Erol C Harvey and Muralidhar K Ghantasala and Geoff M Spinks}
}
```